### PR TITLE
Skip unknown subsystems

### DIFF
--- a/serial/discover_linux.go
+++ b/serial/discover_linux.go
@@ -57,6 +57,8 @@ func Discover() ([]DiscoverInfo, error) {
 			info.Type = PortTypeUsb
 		case "pnp":
 			info.Type = PortTypeIntegrated
+		case "pci":
+			// We recognize the subsystem but we don't have anything to do
 		case "platform":
 			// Not a real serial port, just exposed by the driver
 			continue


### PR DESCRIPTION
On my Ubuntu 16.04 system this library always prints "unknown
subsystem pci".

Library code shouldn't print to stdout but communicate through
return values.

Since this is not an error, let's skip unknown subsystems instead.